### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - setuptools
     - pytest-runner
@@ -36,7 +36,7 @@ tests:
         - cloudstorage
         - cloudstorage.drivers
       pip_check: true
-      python_version: ${{ python_min }}
+      python_version: ${{ python_min }}.*
 
 about:
   summary: Unified cloud storage API for storage services.


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{{{ python_min }}}}` to make them valid match specs.

This is a build-fix only — the existing package on conda-forge is unaffected, so no new build needs to be pushed. That's why the build number isn't bumped.